### PR TITLE
Fix/TransformersRerankPlugin: Fix query and choices encoding

### DIFF
--- a/nboost/plugins/rerank/transformers.py
+++ b/nboost/plugins/rerank/transformers.py
@@ -56,8 +56,9 @@ class PtTransformersRerankPlugin(RerankModelPlugin):
         :param choices:
         :return: Encoded tokens
         """
-        inputs = [self.tokenizer.encode_plus(query, choice, add_special_tokens=True)
-                  for choice in choices]
+        inputs = [self.tokenizer.encode_plus(
+            query, choice, add_special_tokens=True, return_token_type_ids=True, max_length=self.max_seq_len
+            ) for choice in choices]
 
         max_len = min(max(len(t['input_ids']) for t in inputs), self.max_seq_len)
         input_ids = [t['input_ids'][:max_len] +


### PR DESCRIPTION
Fix and improve the usage of encode_plus function:
Set the return_token_type_ids flag to prevent KeyErrors when using
custom models. Currently "token_type_ids" key is not present in the encoded dict
Set max_length while encoding, to reduce computation cost and avoid
unnecessary warnings