### PR TITLE
fixed reranking error as ranks are bigger than choices. Issue#77 Search query not working...

### DIFF
--- a/nboost/plugins/rerank/base.py
+++ b/nboost/plugins/rerank/base.py
@@ -35,7 +35,8 @@ class RerankModelPlugin(Plugin):
         )
         db_row.rerank_time = time.perf_counter() - start_time
 
-        # raise helpful error if choices is shorter than ranks
+        # remove ranks which are higher than total choices
+        ranks = [rank for rank in ranks if rank < len(response.choices)]
         reranked_choices = [response.choices[rank] for rank in ranks]
 
         response.choices = reranked_choices


### PR DESCRIPTION
The issue was with search queries as I have mentioned in open issue #77 Search query not working .
It was re ranking issue where number of ranks are higher than choices.
This change is to fix that problem. Now search query is retrieving results without any issue. @pertschuk 

Previously: 
1. Error if providing query as well Eg: Nboost (Not Working) : http://localhost:8000/<index_name>/_search?q=<query_value>
2. Error if no source value provided Eg : Nboost (Not Working) : http://localhost:8000/<index_name>/_search?q=<query_value>&_source=
3. Error if more than one source provided Eg : Nboost (Not Working) : http://localhost:8000/<index_name>/_search?q=<query_value>&_source=<field_name>,<field_name1>

All the above scenarios are fixed now and working with this change.