### PR TITLE
Corrected right method to run the scripts in docs.

### DIFF
--- a/docs/chapter/elasticsearch.md
+++ b/docs/chapter/elasticsearch.md
@@ -25,7 +25,7 @@ In this example we will set up a proxy to sit in between the client and Elastics
     NBoost has a handy indexing tool built in (`nboost-index`). For demonstration purposes,  will be indexing [a set of passages about traveling and hotels](https://microsoft.github.io/TREC-2019-Deep-Learning/). You can add the index to your Elasticsearch server by running:
     >  `travel.csv` comes with NBoost
     ```bash
-    nboost-index --file travel.csv --name travel --delim ,
+    nboost-index --file travel.csv --index_name travel --delim ,
     ```` 
 
 #### Deploying the proxy

--- a/docs/chapter/getting-started.md
+++ b/docs/chapter/getting-started.md
@@ -36,7 +36,7 @@ If you get this message: `Listening: <host>:<port>`, then we're good to go!
 NBoost has a handy indexing tool built in (`nboost-index`). For demonstration purposes,  will be indexing [a set of passages about traveling and hotels](https://microsoft.github.io/TREC-2019-Deep-Learning/) through NBoost. You can add the index to your Elasticsearch server by running:
 >  `travel.csv` comes with NBoost
 ```bash
-nboost-index --file travel.csv --name travel --delim ,
+nboost-index --file travel.csv --index_name travel --delim ,
 ```` 
 
 


### PR DESCRIPTION
Though readme contains right method but docs have typo in the running script.